### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const data = {
   }
 };
 
-const bulder = RecursionBuilder.create(data);
+const builder = RecursionBuilder.create(data);
 
 for (let [key, value, path, parent] of builder) {
   //=> ['value1', 10, 'value1', data]


### PR DESCRIPTION
In line 67, `builder` was spelled as `bulder`.
Fix this typo.